### PR TITLE
feat: Email_template & unit tests & e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
+.env
 .idea/**
 dist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.24.0",
-    "pydantic>=2.0.0",
+    "pydantic[email]>=2.11.10",
     "python-dateutil>=2.8.0",
     "typing-extensions>=4.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "httpx>=0.24.0",
     "pydantic[email]>=2.11.10",
     "python-dateutil>=2.8.0",
+    "python-dotenv>=1.1.1",
     "typing-extensions>=4.0.0",
 ]
 

--- a/src/escheduler_sdk.egg-info/PKG-INFO
+++ b/src/escheduler_sdk.egg-info/PKG-INFO
@@ -19,7 +19,7 @@ Requires-Python: >=3.9
 Description-Content-Type: text/markdown
 License-File: LICENSE
 Requires-Dist: httpx>=0.24.0
-Requires-Dist: pydantic>=2.0.0
+Requires-Dist: pydantic[email]>=2.11.10
 Requires-Dist: python-dateutil>=2.8.0
 Requires-Dist: typing-extensions>=4.0.0
 Dynamic: license-file

--- a/src/escheduler_sdk.egg-info/PKG-INFO
+++ b/src/escheduler_sdk.egg-info/PKG-INFO
@@ -21,6 +21,7 @@ License-File: LICENSE
 Requires-Dist: httpx>=0.24.0
 Requires-Dist: pydantic[email]>=2.11.10
 Requires-Dist: python-dateutil>=2.8.0
+Requires-Dist: python-dotenv>=1.1.1
 Requires-Dist: typing-extensions>=4.0.0
 Dynamic: license-file
 

--- a/src/escheduler_sdk.egg-info/SOURCES.txt
+++ b/src/escheduler_sdk.egg-info/SOURCES.txt
@@ -7,7 +7,6 @@ src/escheduler_sdk/exceptions.py
 src/escheduler_sdk/models.py
 src/escheduler_sdk/scheduler.py
 src/escheduler_sdk/sdk.py
-src/escheduler_sdk/team.py
 src/escheduler_sdk.egg-info/PKG-INFO
 src/escheduler_sdk.egg-info/SOURCES.txt
 src/escheduler_sdk.egg-info/dependency_links.txt
@@ -17,8 +16,10 @@ src/escheduler_sdk/models/__init__.py
 src/escheduler_sdk/models/enum/__init__.py
 src/escheduler_sdk/models/enum/enums.py
 src/escheduler_sdk/models/pydantic/__init__.py
+src/escheduler_sdk/models/pydantic/email.py
 src/escheduler_sdk/models/pydantic/generic.py
-src/escheduler_sdk/models/pydantic/task.py
-src/escheduler_sdk/models/pydantic/team.py
+src/escheduler_sdk/models/pydantic/scheduler.py
+src/escheduler_sdk/models/template/__init__.py
+src/escheduler_sdk/models/template/strategy_templates.py
 tests/test_client.py
 tests/test_models.py

--- a/src/escheduler_sdk.egg-info/requires.txt
+++ b/src/escheduler_sdk.egg-info/requires.txt
@@ -1,4 +1,4 @@
 httpx>=0.24.0
-pydantic>=2.0.0
+pydantic[email]>=2.11.10
 python-dateutil>=2.8.0
 typing-extensions>=4.0.0

--- a/src/escheduler_sdk.egg-info/requires.txt
+++ b/src/escheduler_sdk.egg-info/requires.txt
@@ -1,4 +1,5 @@
 httpx>=0.24.0
 pydantic[email]>=2.11.10
 python-dateutil>=2.8.0
+python-dotenv>=1.1.1
 typing-extensions>=4.0.0

--- a/src/escheduler_sdk/models/pydantic/__init__.py
+++ b/src/escheduler_sdk/models/pydantic/__init__.py
@@ -7,6 +7,17 @@ from .scheduler import (
     SchedulerStatsResponse,
     TaskStateUpdateRequest,
 )
+from .email import (
+    TemplateVariable,
+    EmailTemplateCreate,
+    EmailTemplateUpdate,
+    EmailTemplateResponse,
+    EmailTaskCreate,
+    EmailTaskUpdate,
+    EmailTaskResponse,
+    EmailSendRequest,
+    EmailSendResponse,
+)
 
 __all__ = [
     "MessageResponse",
@@ -17,4 +28,13 @@ __all__ = [
     "TaskExecutionResponse",
     "SchedulerStatsResponse",
     "TaskStateUpdateRequest",
+    "TemplateVariable",
+    "EmailTemplateCreate",
+    "EmailTemplateUpdate",
+    "EmailTemplateResponse",
+    "EmailTaskCreate",
+    "EmailTaskUpdate",
+    "EmailTaskResponse",
+    "EmailSendRequest",
+    "EmailSendResponse",
 ]

--- a/src/escheduler_sdk/models/pydantic/email.py
+++ b/src/escheduler_sdk/models/pydantic/email.py
@@ -1,0 +1,188 @@
+from datetime import datetime
+from typing import Optional, Dict, Any, List
+from pydantic import BaseModel, Field, field_validator, EmailStr
+
+class TemplateVariable(BaseModel):
+    """模板變數定義"""
+    name: str = Field(..., description="變數名稱")
+    type: str = Field("string", description="變數類型: string, number, email, date, boolean")
+    description: Optional[str] = Field(None, description="變數描述")
+    required: bool = Field(False, description="是否必填")
+    default_value: Optional[Any] = Field(None, description="預設值")
+    validation_pattern: Optional[str] = Field(None, description="驗證正則表達式")
+    
+    @field_validator('type')
+    def validate_type(cls, v):
+        allowed_types = ['string', 'number', 'email', 'date', 'boolean']
+        if v not in allowed_types:
+            raise ValueError(f'變數類型必須是: {", ".join(allowed_types)}')
+        return v
+
+class EmailTemplateCreate(BaseModel):
+    """創建 Email 模板請求模型"""
+    name: str = Field(..., min_length=1, max_length=255, description="模板名稱")
+    description: Optional[str] = Field(None, description="模板描述")
+    subject_template: str = Field(..., min_length=1, max_length=500, description="主旨模板")
+    body_template: str = Field(..., min_length=1, description="內容模板")
+    html_template: Optional[str] = Field(None, description="HTML 模板")
+    variables: List[TemplateVariable] = Field(default=[], description="模板變數定義")
+    default_sender: Optional[EmailStr] = Field(None, description="預設寄件人")
+    default_cc: Optional[List[EmailStr]] = Field(None, description="預設副本收件人")
+    default_bcc: Optional[List[EmailStr]] = Field(None, description="預設密件副本收件人")
+    is_active: bool = Field(True, description="是否啟用")
+
+
+class EmailTemplateUpdate(BaseModel):
+    """更新 Email 模板請求模型"""
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = None
+    subject_template: Optional[str] = Field(None, min_length=1, max_length=500)
+    body_template: Optional[str] = Field(None, min_length=1)
+    html_template: Optional[str] = None
+    variables: Optional[List[TemplateVariable]] = None
+    default_sender: Optional[EmailStr] = None
+    default_cc: Optional[List[EmailStr]] = None
+    default_bcc: Optional[List[EmailStr]] = None
+    is_active: Optional[bool] = None
+
+
+class EmailTemplateResponse(BaseModel):
+    """Email 模板回應模型"""
+    id: int
+    name: str
+    description: Optional[str]
+    subject_template: str
+    body_template: str
+    html_template: Optional[str]
+    variables: List[Dict[str, Any]]
+    default_sender: Optional[str]
+    default_cc: Optional[List[str]]
+    default_bcc: Optional[List[str]]
+    is_active: bool
+    is_system_template: bool
+    usage_count: int
+    last_used_at: Optional[datetime]
+    created_at: datetime
+    updated_at: datetime
+    
+    class Config:
+        from_attributes = True
+
+
+
+class EmailTaskCreate(BaseModel):
+    """創建 Email 任務請求模型"""
+    # 基本任務資訊
+    name: str = Field(..., min_length=1, max_length=255, description="任務名稱")
+    description: Optional[str] = Field(None, description="任務描述")
+    schedule_expression: str = Field(..., description="排程表達式")
+    timezone: str = Field("Asia/Taipei", description="時區")
+    
+    # Email 特定設定
+    use_template: bool = Field(False, description="是否使用模板")
+    template_id: Optional[int] = Field(None, description="模板 ID")
+    template_variables: Optional[Dict[str, Any]] = Field(None, description="模板變數值")
+    
+    # 直接 Email 設定 (不使用模板時)
+    subject: Optional[str] = Field(None, description="郵件主旨")
+    body: Optional[str] = Field(None, description="郵件內容")
+    html_body: Optional[str] = Field(None, description="HTML 內容")
+    
+    # 收件人設定
+    recipients: List[EmailStr] = Field(..., min_items=1, description="收件人列表")
+    cc: Optional[List[EmailStr]] = Field(None, description="副本收件人")
+    bcc: Optional[List[EmailStr]] = Field(None, description="密件副本收件人")
+    sender: Optional[EmailStr] = Field(None, description="寄件人")
+    
+    # 任務設定
+    max_retry_attempts: int = Field(3, ge=0, le=10, description="最大重試次數")
+    retry_policy: Optional[Dict[str, Any]] = Field(None, description="重試策略")
+    
+    @field_validator('template_id')
+    def validate_template_usage(cls, v, values):
+        use_template = values.get('use_template', False)
+        if use_template and not v:
+            raise ValueError('使用模板時必須提供 template_id')
+        return v
+    
+    @field_validator('subject')
+    def validate_direct_email_fields(cls, v, values):
+        use_template = values.get('use_template', False)
+        if not use_template and not v:
+            raise ValueError('不使用模板時必須提供 subject')
+        return v
+
+
+class EmailTaskUpdate(BaseModel):
+    """更新 Email 任務請求模型"""
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = None
+    schedule_expression: Optional[str] = None
+    timezone: Optional[str] = None
+    use_template: Optional[bool] = None
+    template_id: Optional[int] = None
+    template_variables: Optional[Dict[str, Any]] = None
+    subject: Optional[str] = None
+    body: Optional[str] = None
+    html_body: Optional[str] = None
+    recipients: Optional[List[EmailStr]] = None
+    cc: Optional[List[EmailStr]] = None
+    bcc: Optional[List[EmailStr]] = None
+    sender: Optional[EmailStr] = None
+    max_retry_attempts: Optional[int] = Field(None, ge=0, le=10)
+    retry_policy: Optional[Dict[str, Any]] = None
+
+
+class EmailTaskResponse(BaseModel):
+    """Email 任務回應模型"""
+    id: int
+    name: str
+    description: Optional[str]
+    schedule_expression: str
+    timezone: str
+    target_type: str
+    target_arn: str
+    target_input: Dict[str, Any]
+    state: str
+    last_execution_time: Optional[datetime]
+    next_execution_time: Optional[datetime]
+    execution_count: int
+    max_retry_attempts: int
+    created_at: datetime
+    updated_at: datetime
+    
+    # Email 特定資訊
+    use_template: bool
+    template_id: Optional[int]
+    template_name: Optional[str]
+    recipients: List[str]
+    
+    class Config:
+        from_attributes = True
+
+
+class EmailSendRequest(BaseModel):
+    """立即發送 Email 請求模型"""
+    use_template: bool = Field(False, description="是否使用模板")
+    template_id: Optional[int] = Field(None, description="模板 ID")
+    template_variables: Optional[Dict[str, Any]] = Field(None, description="模板變數值")
+    
+    # 直接 Email 設定
+    subject: Optional[str] = Field(None, description="郵件主旨")
+    body: Optional[str] = Field(None, description="郵件內容")
+    html_body: Optional[str] = Field(None, description="HTML 內容")
+    
+    # 收件人設定
+    recipients: List[EmailStr] = Field(..., min_items=1, description="收件人列表")
+    cc: Optional[List[EmailStr]] = Field(None, description="副本收件人")
+    bcc: Optional[List[EmailStr]] = Field(None, description="密件副本收件人")
+    sender: Optional[EmailStr] = Field(None, description="寄件人")
+
+
+class EmailSendResponse(BaseModel):
+    """Email 發送回應模型"""
+    success: bool = Field(..., description="是否發送成功")
+    message: str = Field(..., description="發送結果訊息")
+    usage_id: Optional[int] = Field(None, description="使用記錄 ID")
+    execution_time: float = Field(..., description="執行時間 (秒)")
+    data: Optional[Dict[str, Any]] = Field(None, description="額外資料")

--- a/src/escheduler_sdk/models/template/__init__.py
+++ b/src/escheduler_sdk/models/template/__init__.py
@@ -5,6 +5,7 @@ from .strategy_templates import (
     WebhookTaskTemplate,
     RabbitMQTaskTemplate,
     EmailTaskTemplate,
+    EmailTemplateCreateTemplate
 )
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "WebhookTaskTemplate",
     "RabbitMQTaskTemplate",
     "EmailTaskTemplate",
+    "EmailTemplateCreateTemplate"
 ]

--- a/src/escheduler_sdk/models/template/strategy_templates.py
+++ b/src/escheduler_sdk/models/template/strategy_templates.py
@@ -2,7 +2,7 @@
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, List
 
-from ..pydantic import ScheduledTaskCreate
+from ..pydantic import ScheduledTaskCreate, EmailTemplateCreate, TemplateVariable
 from ..enum import TargetType
 
 
@@ -145,39 +145,173 @@ class RabbitMQTaskTemplate(BaseTaskTemplate):
 
 class EmailTaskTemplate(BaseTaskTemplate):
     """用於創建 Email 目標類型任務的範本"""
+
     def __init__(
         self,
         name: str,
-        subject: str,
-        recipients: List[str],
-        body: str,
         schedule_expression: str,
+        # Direct email settings (if not using a template)
+        subject: Optional[str] = None,
+        recipients: Optional[List[str]] = None,
+        body: Optional[str] = None,
+        html_body: Optional[str] = None,
+        cc: Optional[List[str]] = None,
+        bcc: Optional[List[str]] = None,
+        sender: Optional[str] = None,
+        # Template settings
+        use_template: bool = False,
+        template_id: Optional[int] = None,
+        template_variables: Optional[Dict[str, Any]] = None,
+        # Common task settings
         description: Optional[str] = None,
         max_retry_attempts: int = 2,
         timezone: str = "Asia/Taipei",
     ):
+        """
+        初始化 Email 任務範本
+
+        Args:
+            name (str): 任務名稱
+            schedule_expression (str): 排程表達式 (例如 "cron(* * * * *)" 或 "rate(1 minute)")
+
+            subject (Optional[str]): 郵件主旨 (不使用模板時為必填)
+            recipients (Optional[List[str]]): 收件人列表 (不使用模板時為必填)
+            body (Optional[str]): 純文字郵件內容
+            html_body (Optional[str]): HTML 郵件內容
+            cc (Optional[List[str]]): 副本收件人列表
+            bcc (Optional[List[str]]): 密件副本收件人列表
+            sender (Optional[str]): 寄件人
+
+            use_template (bool): 是否使用模板. Defaults to False.
+            template_id (Optional[int]): 模板 ID (使用模板時為必填)
+            template_variables (Optional[Dict[str, Any]]): 模板變數
+
+            description (Optional[str]): 任務描述
+            max_retry_attempts (int): 最大重試次數. Defaults to 2.
+            timezone (str): 任務執行的時區. Defaults to "Asia/Taipei".
+        """
+        if use_template:
+            if not template_id:
+                raise ValueError("使用模板時，必須提供 'template_id'")
+        else:
+            if not subject:
+                raise ValueError("不使用模板時，必須提供 'subject'")
+            if not recipients:
+                raise ValueError("不使用模板時，必須提供 'recipients'")
+
         self.name = name
-        self.subject = subject
-        self.recipients = recipients
-        self.body = body
         self.schedule_expression = schedule_expression
         self.description = description
         self.max_retry_attempts = max_retry_attempts
         self.timezone = timezone
 
+        # Email specific attributes
+        self.use_template = use_template
+        self.template_id = template_id
+        self.template_variables = template_variables
+        self.subject = subject
+        self.body = body
+        self.html_body = html_body
+        self.recipients = recipients
+        self.cc = cc
+        self.bcc = bcc
+        self.sender = sender
+
     def build(self) -> ScheduledTaskCreate:
         """構建 ScheduledTaskCreate 物件"""
+        target_arn = (
+            self.subject
+            if not self.use_template
+            else f"email:template_id:{self.template_id}"
+        )
+
         target_input = {
-            "recipients": self.recipients,
+            "use_template": self.use_template,
+            "template_id": self.template_id,
+            "template_variables": self.template_variables,
+            "subject": self.subject,
             "body": self.body,
+            "html_body": self.html_body,
+            "recipients": self.recipients,
+            "cc": self.cc,
+            "bcc": self.bcc,
+            "sender": self.sender,
         }
+
+        # Remove keys with None values to keep the payload clean
+        final_target_input = {k: v for k, v in target_input.items() if v is not None}
+
+        # If using template, we don't need to send subject/body in target_input
+        if self.use_template:
+            final_target_input.pop("subject", None)
+            final_target_input.pop("body", None)
+            final_target_input.pop("html_body", None)
+
         return ScheduledTaskCreate(
             name=self.name,
             description=self.description,
             schedule_expression=self.schedule_expression,
             timezone=self.timezone,
             target_type=TargetType.EMAIL,
-            target_arn=self.subject,
-            target_input=target_input,
+            target_arn=target_arn,
+            target_input=final_target_input,
             max_retry_attempts=self.max_retry_attempts,
+        )
+
+
+class EmailTemplateCreateTemplate:
+    """用於創建 Email 模板的範本"""
+
+    def __init__(
+        self,
+        name: str,
+        subject_template: str,
+        body_template: str,
+        description: Optional[str] = None,
+        html_template: Optional[str] = None,
+        variables: Optional[List[TemplateVariable]] = None,
+        default_sender: Optional[str] = None,
+        default_cc: Optional[List[str]] = None,
+        default_bcc: Optional[List[str]] = None,
+        is_active: bool = True,
+    ):
+        """
+        初始化 Email 模板創建範本
+
+        Args:
+            name (str): 模板名稱
+            subject_template (str): 主旨模板
+            body_template (str): 內容模板
+            description (Optional[str]): 模板描述
+            html_template (Optional[str]): HTML 模板
+            variables (Optional[List[TemplateVariable]]): 模板變數定義
+            default_sender (Optional[str]): 預設寄件人
+            default_cc (Optional[List[str]]): 預設副本收件人
+            default_bcc (Optional[List[str]]): 預設密件副本收件人
+            is_active (bool): 是否啟用
+        """
+        self.name = name
+        self.subject_template = subject_template
+        self.body_template = body_template
+        self.description = description
+        self.html_template = html_template
+        self.variables = variables if variables is not None else []
+        self.default_sender = default_sender
+        self.default_cc = default_cc
+        self.default_bcc = default_bcc
+        self.is_active = is_active
+
+    def build(self) -> EmailTemplateCreate:
+        """構建 EmailTemplateCreate 物件"""
+        return EmailTemplateCreate(
+            name=self.name,
+            description=self.description,
+            subject_template=self.subject_template,
+            body_template=self.body_template,
+            html_template=self.html_template,
+            variables=self.variables,
+            default_sender=self.default_sender,
+            default_cc=self.default_cc,
+            default_bcc=self.default_bcc,
+            is_active=self.is_active,
         )

--- a/src/escheduler_sdk/scheduler.py
+++ b/src/escheduler_sdk/scheduler.py
@@ -12,6 +12,10 @@ from .models import (
     TaskState,
     MessageResponse,
     BaseTaskTemplate,
+    EmailTemplateCreateTemplate,
+    EmailTemplateCreate,
+    EmailTemplateResponse,
+    EmailTemplateUpdate,
 )
 
 
@@ -27,6 +31,7 @@ class SchedulerAPI:
         """
         self.client = client
         self.base_endpoint = "/api/scheduler"
+        self.template_endpoint = "/api/email-templates"
     
     async def create_task(
         self, 
@@ -59,6 +64,75 @@ class SchedulerAPI:
             json_data=task_data.model_dump(exclude_none=True)
         )
         return ScheduledTaskResponse(**response_data)
+
+    async def create_email_template(
+        self,
+        template: Union[EmailTemplateCreate, EmailTemplateCreateTemplate]
+    ) -> EmailTemplateResponse:
+        """
+        創建新的 Email 模板。
+
+        可以接受一個完整的 `EmailTemplateCreate` 模型，
+        或者一個 `EmailTemplateCreateTemplate` 的實例來快速創建模板。
+
+        Args:
+            template: 模板創建數據模型或模板範本
+
+        Returns:
+            創建的模板信息
+
+        Raises:
+            ValidationError: 當模板數據驗證失敗時
+            AuthenticationError: 當認證失敗時
+            ESchedulerError: 其他 API 錯誤
+        """
+        if isinstance(template, EmailTemplateCreateTemplate):
+            template_data = template.build()
+        else:
+            template_data = template
+
+        response_data = await self.client.post(
+            self.template_endpoint,
+            json_data=template_data.model_dump(exclude_none=True)
+        )
+        return EmailTemplateResponse(**response_data)
+
+    async def update_email_template(
+        self, 
+        template_id: int, 
+        template_data: EmailTemplateUpdate
+    ) -> EmailTemplateResponse:
+        """
+        更新排程任務
+        
+        Args:
+            task_id: 任務 ID
+            task_data: 任務更新數據
+            
+        Returns:
+            更新後的任務信息
+            
+        Raises:
+            NotFoundError: 當任務不存在時
+            ValidationError: 當更新數據驗證失敗時
+        """
+        response_data = await self.client.put(
+            f"{self.template_endpoint}/{template_id}",
+            json_data=template_data.model_dump(exclude_none=True)
+        )
+        return EmailTemplateResponse(**response_data)
+
+    async def delete_email_template(self, template_id: int):
+        """
+        刪除 Email 模板。
+
+        Args:
+            template_id: 模板 ID
+
+        Raises:
+            NotFoundError: 當模板不存在時
+        """
+        await self.client.delete(f"{self.template_endpoint}/{template_id}")
     
     async def get_all_tasks(
         self, 

--- a/tests/e2e/test_email_features_e2e.py
+++ b/tests/e2e/test_email_features_e2e.py
@@ -1,0 +1,154 @@
+"""Email 相關功能的端到端測試"""
+import pytest
+import os
+from datetime import datetime
+
+from escheduler_sdk import ESchedulerSDK
+from escheduler_sdk.models import (
+    EmailTemplateCreateTemplate,
+    TemplateVariable,
+    EmailTaskTemplate,
+)
+from escheduler_sdk.exceptions import NotFoundError, ESchedulerError
+
+# --- 測試設定 ---
+BASE_URL = os.getenv("ESCHEDULER_BASE_URL", "http://localhost:8000")
+JWT_TOKEN = os.getenv("ESCHEDULER_JWT_TOKEN", "test-jwt-token")
+TARGET_EMAIL = os.getenv("TARGET_EMAIL", None)
+
+# 如果未設定環境變數，則跳過此模組中的所有測試
+pytestmark = pytest.mark.skipif(
+    not all([BASE_URL, JWT_TOKEN]),
+    reason="必須設定 ESCHEDULER_BASE_URL 和 ESCHEDULER_JWT_TOKEN 才能執行 E2E 測試",
+)
+
+
+@pytest.mark.e2e
+class TestEmailFeaturesE2E:
+    """Email 功能的端到端測試"""
+
+    @pytest.fixture(scope="class")
+    def e2e_config(self):
+        """E2E 測試設定"""
+        return {
+            "base_url": BASE_URL,
+            "jwt_token": JWT_TOKEN,
+            "timeout": 30.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_email_template(self, e2e_config):
+        """測試創建和刪除 Email 模板"""
+        template_to_create = EmailTemplateCreateTemplate(
+            name=f"e2e-template-{int(datetime.now().timestamp())}",
+            subject_template="你好 {{ name }}!",
+            body_template="這是一個給使用者 {{ name }} 的 E2E 測試。",
+            variables=[
+                TemplateVariable(name="name", type="string", required=True)
+            ],
+        )
+        
+        created_template = None
+        try:
+            async with ESchedulerSDK(**e2e_config) as sdk:
+                created_template = await sdk.scheduler.create_email_template(template_to_create)
+            
+                assert created_template is not None
+                assert created_template.id is not None
+                assert "e2e-template" in created_template.name
+                assert len(created_template.variables) == 1
+                assert created_template.variables[0]["name"] == "name"
+        finally:
+            if created_template:
+                try:
+                    async with ESchedulerSDK(**e2e_config) as sdk:
+                        await sdk.scheduler.delete_email_template(created_template.id)
+                        print(f"模板 {created_template.id} 清理成功。")
+                except (NotFoundError, ESchedulerError) as e:
+                    pytest.fail(f"清理模板 {created_template.id} 失敗：{e}")
+
+    @pytest.mark.asyncio
+    async def test_create_task_with_template(self, e2e_config):
+        """測試使用 Email 模板創建排程任務"""
+        # 步驟 1: 創建一個依賴的 Email 模板
+        template_to_create = EmailTemplateCreateTemplate(
+            name=f"e2e-dependency-template-{int(datetime.now().timestamp())}",
+            subject_template="依賴模板: {{ name }}",
+            body_template="依賴模板的內容。",
+            variables=[TemplateVariable(name="name", type="string")],
+        )
+        
+        created_template = None
+        created_task = None
+        
+        try:
+            async with ESchedulerSDK(**e2e_config) as sdk:
+                created_template = await sdk.scheduler.create_email_template(template_to_create)
+                assert created_template is not None, "前置模板創建失敗"
+
+                # 步驟 2: 使用創建的模板來創建任務
+                task_to_create = EmailTaskTemplate(
+                    name=f"e2e-task-with-template-{int(datetime.now().timestamp())}",
+                    schedule_expression="cron(0 0 1 1 *)",  # 每年一次
+                    use_template=True,
+                    template_id=created_template.id,
+                    recipients=[TARGET_EMAIL or "test@example.com"],
+                    template_variables={"name": "E2E 使用者"},
+                )
+            
+                created_task = await sdk.scheduler.create_task(task_to_create)
+                assert created_task is not None
+                assert created_task.id is not None
+                assert "e2e-task-with-template" in created_task.name
+                assert created_task.target_input.get("use_template") is True
+                assert created_task.target_input.get("template_id") == created_template.id
+
+                # 手動發送測試(如果有輸入 TARGET_EMAIL)
+                if TARGET_EMAIL:
+                    await sdk.scheduler.trigger_task(created_task.id)
+
+        finally:
+            # 步驟 3: 清理創建的資源
+            async with ESchedulerSDK(**e2e_config) as sdk:
+                if created_task:
+                    try:
+                        await sdk.scheduler.delete_task(created_task.id)
+                        print(f"任務 {created_task.id} 清理成功。")
+                    except (NotFoundError, ESchedulerError) as e:
+                        pytest.fail(f"清理任務 {created_task.id} 失敗：{e}")
+                if created_template:
+                    try:
+                        await sdk.scheduler.delete_email_template(created_template.id)
+                        print(f"模板 {created_template.id} 清理成功。")
+                    except (NotFoundError, ESchedulerError) as e:
+                        pytest.fail(f"清理模板 {created_template.id} 失敗：{e}")
+
+    @pytest.mark.asyncio
+    async def test_create_direct_email_task(self, e2e_config):
+        """測試不使用模板直接創建 Email 排程任務"""
+        task_to_create = EmailTaskTemplate(
+            name=f"e2e-direct-email-task-{int(datetime.now().timestamp())}",
+            schedule_expression="rate(1 day)",
+            subject="直接的 E2E 測試郵件",
+            recipients=["direct@example.com"],
+            body="這是一封來自 E2E 測試的直接郵件內容。",
+            use_template=False,
+        )
+
+        created_task = None
+        try:
+            async with ESchedulerSDK(**e2e_config) as sdk:
+                created_task = await sdk.scheduler.create_task(task_to_create)
+                assert created_task is not None
+                assert created_task.id is not None
+                assert "e2e-direct-email-task" in created_task.name
+                assert created_task.target_arn == "直接的 E2E 測試郵件"
+                assert created_task.target_input.get("use_template") is False
+
+        finally:
+            if created_task:
+                try:
+                    async with ESchedulerSDK(**e2e_config) as sdk:
+                        await sdk.scheduler.delete_task(created_task.id)
+                except (NotFoundError, ESchedulerError) as e:
+                    pytest.fail(f"清理任務 {created_task.id} 失敗：{e}")

--- a/tests/e2e/test_email_features_e2e.py
+++ b/tests/e2e/test_email_features_e2e.py
@@ -2,6 +2,7 @@
 import pytest
 import os
 from datetime import datetime
+from dotenv import load_dotenv
 
 from escheduler_sdk import ESchedulerSDK
 from escheduler_sdk.models import (
@@ -12,6 +13,7 @@ from escheduler_sdk.models import (
 from escheduler_sdk.exceptions import NotFoundError, ESchedulerError
 
 # --- 測試設定 ---
+load_dotenv()
 BASE_URL = os.getenv("ESCHEDULER_BASE_URL", "http://localhost:8000")
 JWT_TOKEN = os.getenv("ESCHEDULER_JWT_TOKEN", "test-jwt-token")
 TARGET_EMAIL = os.getenv("TARGET_EMAIL", None)

--- a/tests/unit/test_strategy_template.py
+++ b/tests/unit/test_strategy_template.py
@@ -1,11 +1,13 @@
-"""任務創建範本的單元測試"""
 import pytest
 from escheduler_sdk.models import (
     HttpTaskTemplate,
     WebhookTaskTemplate,
     RabbitMQTaskTemplate,
     EmailTaskTemplate,
+    EmailTemplateCreateTemplate,
+    TemplateVariable,
     ScheduledTaskCreate,
+    EmailTemplateCreate,
     TargetType,
 )
 
@@ -24,11 +26,7 @@ class TestTaskTemplates:
             target_input={"method": "POST", "json": {"key": "value"}},
             max_retry_attempts=5,
         )
-
-        # 執行測試
         task_model = template.build()
-
-        # 驗證結果
         assert isinstance(task_model, ScheduledTaskCreate)
         assert task_model.name == "Test HTTP Task"
         assert task_model.target_type == TargetType.HTTP
@@ -37,7 +35,7 @@ class TestTaskTemplates:
         assert task_model.description == "A test HTTP task"
         assert task_model.target_input == {"method": "POST", "json": {"key": "value"}}
         assert task_model.max_retry_attempts == 5
-        assert task_model.timezone == "Asia/Taipei"  # 驗證預設值
+        assert task_model.timezone == "Asia/Taipei"
 
     def test_webhook_task_template(self):
         """驗證 WebhookTaskTemplate 是否能正確構建 ScheduledTaskCreate 物件"""
@@ -47,18 +45,14 @@ class TestTaskTemplates:
             schedule_expression="cron(0 0 * * *)",
             payload={"event": "test", "user": "gemini"},
         )
-
-        # 執行測試
         task_model = template.build()
-
-        # 驗證結果
         assert isinstance(task_model, ScheduledTaskCreate)
         assert task_model.name == "Test Webhook"
         assert task_model.target_type == TargetType.WEBHOOK
         assert task_model.target_arn == "http://example.com/webhook"
         assert task_model.schedule_expression == "cron(0 0 * * *)"
         assert task_model.target_input == {"event": "test", "user": "gemini"}
-        assert task_model.max_retry_attempts == 5  # 驗證預設值
+        assert task_model.max_retry_attempts == 5
 
     def test_rabbitmq_task_template(self):
         """驗證 RabbitMQTaskTemplate 是否能正確構建 ScheduledTaskCreate 物件"""
@@ -70,11 +64,7 @@ class TestTaskTemplates:
             exchange="my_exchange",
             properties={"content_type": "application/json"},
         )
-
-        # 執行測試
         task_model = template.build()
-
-        # 驗證結果
         assert isinstance(task_model, ScheduledTaskCreate)
         assert task_model.name == "Test RabbitMQ Message"
         assert task_model.target_type == TargetType.RABBITMQ
@@ -84,25 +74,93 @@ class TestTaskTemplates:
         assert task_model.target_input["payload"] == {"message": "hello world"}
         assert task_model.target_input["properties"] == {"content_type": "application/json"}
 
-    def test_email_task_template(self):
-        """驗證 EmailTaskTemplate 是否能正確構建 ScheduledTaskCreate 物件"""
+    def test_email_task_template_direct_build(self):
+        """驗證 EmailTaskTemplate (Direct) 是否能正確構建"""
         template = EmailTaskTemplate(
-            name="Daily Report Email",
-            subject="Daily Report",
-            recipients=["test@example.com", "admin@example.com"],
-            body="This is the daily report.",
+            name="Direct Report Email",
+            subject="Direct Report",
+            recipients=["test@example.com"],
+            body="This is the direct report.",
             schedule_expression="cron(0 8 * * *)",
         )
-
-        # 執行測試
         task_model = template.build()
-
-        # 驗證結果
         assert isinstance(task_model, ScheduledTaskCreate)
-        assert task_model.name == "Daily Report Email"
+        assert task_model.name == "Direct Report Email"
         assert task_model.target_type == TargetType.EMAIL
-        assert task_model.target_arn == "Daily Report"
-        assert task_model.schedule_expression == "cron(0 8 * * *)"
-        assert task_model.target_input["recipients"] == ["test@example.com", "admin@example.com"]
-        assert task_model.target_input["body"] == "This is the daily report."
-        assert task_model.max_retry_attempts == 2  # 驗證預設值
+        assert task_model.target_arn == "Direct Report"
+        assert task_model.target_input["recipients"] == ["test@example.com"]
+        assert task_model.target_input["body"] == "This is the direct report."
+        assert task_model.target_input["use_template"] is False
+
+    def test_email_task_template_with_template_build(self):
+        """驗證 EmailTaskTemplate (With Template) 是否能正確構建"""
+        template = EmailTaskTemplate(
+            name="Template Report Email",
+            schedule_expression="cron(0 9 * * *)",
+            use_template=True,
+            template_id=123,
+            recipients=["template@example.com"],
+            template_variables={"user": "Gemini"},
+        )
+        task_model = template.build()
+        assert isinstance(task_model, ScheduledTaskCreate)
+        assert task_model.name == "Template Report Email"
+        assert task_model.target_type == TargetType.EMAIL
+        assert task_model.target_arn == "email:template_id:123"
+        assert task_model.target_input["use_template"] is True
+        assert task_model.target_input["template_id"] == 123
+        assert task_model.target_input["template_variables"] == {"user": "Gemini"}
+        assert "subject" not in task_model.target_input
+        assert "body" not in task_model.target_input
+
+    def test_email_task_template_validation(self):
+        """驗證 EmailTaskTemplate 的初始化驗證邏輯"""
+        # 使用模板但未提供 template_id
+        with pytest.raises(ValueError, match="必須提供 'template_id'"):
+            EmailTaskTemplate(
+                name="Invalid Template Task",
+                schedule_expression="rate(1m)",
+                use_template=True,
+                recipients=["test@example.com"],
+            )
+
+        # 不使用模板但未提供 subject
+        with pytest.raises(ValueError, match="必須提供 'subject'"):
+            EmailTaskTemplate(
+                name="Invalid Direct Task",
+                schedule_expression="rate(1m)",
+                use_template=False,
+                recipients=["test@example.com"],
+                body="some body",
+            )
+
+        # 不使用模板但未提供 recipients
+        with pytest.raises(ValueError, match="必須提供 'recipients'"):
+            EmailTaskTemplate(
+                name="Invalid Direct Task",
+                schedule_expression="rate(1m)",
+                use_template=False,
+                subject="some subject",
+            )
+
+    def test_email_template_create_template_build(self):
+        """驗證 EmailTemplateCreateTemplate 是否能正確構建"""
+        variables = [
+            TemplateVariable(name="user_name", type="string", required=True),
+            TemplateVariable(name="order_id", type="number"),
+        ]
+        template = EmailTemplateCreateTemplate(
+            name="Test Email Template",
+            subject_template="Order {{ order_id }} for {{ user_name }}",
+            body_template="Details for order {{ order_id }}.",
+            html_template="<p>Details for order {{ order_id }}.</p>",
+            variables=variables,
+            default_sender="noreply@example.com",
+        )
+        template_model = template.build()
+        assert isinstance(template_model, EmailTemplateCreate)
+        assert template_model.name == "Test Email Template"
+        assert template_model.subject_template == "Order {{ order_id }} for {{ user_name }}"
+        assert len(template_model.variables) == 2
+        assert template_model.variables[0].name == "user_name"
+        assert template_model.default_sender == "noreply@example.com"

--- a/uv.lock
+++ b/uv.lock
@@ -485,6 +485,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic", extra = ["email"] },
     { name = "python-dateutil" },
+    { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
 
@@ -509,6 +510,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.10" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
 
@@ -1189,6 +1191,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -431,6 +431,30 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -440,12 +464,26 @@ wheels = [
 ]
 
 [[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dnspython", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "escheduler-sdk"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
@@ -469,7 +507,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.24.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.11.10" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
@@ -916,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.7"
+version = "2.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -924,9 +962,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494, upload-time = "2025-10-04T10:40:41.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", size = 444823, upload-time = "2025-10-04T10:40:39.055Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -1376,14 +1419,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# 新增內容
- `Email Template` & Email 相關功能
- `Email feature` 的 `unit tests、e2e tests`

# Issue
#7 #8 

----

# e2e 測試結果
- 可以在 `.env` 新增 `TARGET_EMAIL` 用於接收 e2e 測試所發送的 email
- 目前 `email_strategy` 尚未完成 `_send_direct_email` ，故只會發送包含 `template` 的 email
<img width="719" height="452" alt="image" src="https://github.com/user-attachments/assets/daefe63f-1d5b-41c4-ad72-7b9615911fb7" />
